### PR TITLE
매직1분VN - 레짐 필터 계산 안정화

### DIFF
--- a/magic1min_vn.pine
+++ b/magic1min_vn.pine
@@ -752,9 +752,14 @@ bool equitySlopeOK_L=not useEquitySlopeFilter or eqSlope>=0
 bool equitySlopeOK_S=not useEquitySlopeFilter or eqSlope<=0
 float regimeClose = request.security(syminfo.tickerid, ctxHtfTf, close, lookahead=barmerge.lookahead_off)
 float regimeEma = request.security(syminfo.tickerid, ctxHtfTf, ta.ema(close, ctxHtfEmaLen), lookahead=barmerge.lookahead_off)
-float regimeAdx = request.security(syminfo.tickerid, ctxHtfTf, ta.adx(ctxHtfAdxLen), lookahead=barmerge.lookahead_off)
-bool regimeLongOK = not useRegimeFilter or (regimeClose > regimeEma and regimeAdx > ctxHtfAdxTh)
-bool regimeShortOK = not useRegimeFilter or (regimeClose < regimeEma and regimeAdx > ctxHtfAdxTh)
+float regimeAdx = request.security(syminfo.tickerid, ctxHtfTf, f_adx(ctxHtfAdxLen), lookahead=barmerge.lookahead_off)
+float regimeCloseVal = useRegimeFilter ? nz(regimeClose, close) : close
+float currentEma = ta.ema(close, ctxHtfEmaLen)
+float regimeEmaVal = useRegimeFilter ? nz(regimeEma, currentEma) : currentEma
+float currentAdx = f_adx(ctxHtfAdxLen)
+float regimeAdxVal = useRegimeFilter ? nz(regimeAdx, currentAdx) : currentAdx
+bool regimeLongOK = not useRegimeFilter or (regimeCloseVal > regimeEmaVal and regimeAdxVal > ctxHtfAdxTh)
+bool regimeShortOK = not useRegimeFilter or (regimeCloseVal < regimeEmaVal and regimeAdxVal > ctxHtfAdxTh)
 
 // --- 최종 진입 조건 결합 ---
 bool ctxLongOk = regimeLongOK and slopeOK_L and distanceOK_L and equitySlopeOK_L


### PR DESCRIPTION
## 요약
- HTF 레짐 계산 구간에서 항상 보조 지표를 요청하도록 구조를 정리했습니다.
- 레짐 비활성 시 현 타임프레임 데이터를 안전하게 폴백하도록 보강했습니다.

## 테스트
- 별도 테스트 없음

------
https://chatgpt.com/codex/tasks/task_e_68daa6b560188320be15bd3d59a84ab0