### PR TITLE
Optuna 최적화 None 반환 수정

### DIFF
--- a/optimize/run.py
+++ b/optimize/run.py
@@ -959,20 +959,20 @@ def optimisation_loop(
         dataset_metrics: List[Dict[str, object]] = []
         numeric_metrics: List[Dict[str, float]] = []
 
-    def _sanitise(value: float, stage: str) -> float:
-        try:
-            numeric = float(value)
-        except Exception:
-            numeric = non_finite_penalty
-        if not np.isfinite(numeric):
-            LOGGER.warning(
-                "Non-finite %s score detected for trial %s; applying penalty %.0e",
-                stage,
-                trial.number,
-                non_finite_penalty,
-            )
-            return non_finite_penalty
-        return numeric
+        def _sanitise(value: float, stage: str) -> float:
+            try:
+                numeric = float(value)
+            except Exception:
+                numeric = non_finite_penalty
+            if not np.isfinite(numeric):
+                LOGGER.warning(
+                    "Non-finite %s score detected for trial %s; applying penalty %.0e",
+                    stage,
+                    trial.number,
+                    non_finite_penalty,
+                )
+                return non_finite_penalty
+            return numeric
 
         for idx, dataset in enumerate(selected_datasets, start=1):
             metrics = run_backtest(dataset.df, params, fees, risk, htf_df=dataset.htf)


### PR DESCRIPTION
## Summary
- objective 함수 내부 블록의 들여쓰기를 바로잡아 Optuna가 None 값을 받는 문제를 해결했습니다.
- 점수 보정 함수가 trial 컨텍스트를 안전하게 참조하도록 objective 내부로 옮겼습니다.

## Testing
- 미실행 (pandas, matplotlib, optuna 등 필수 의존성이 환경에 설치되어 있지 않음)


------
https://chatgpt.com/codex/tasks/task_e_68dadd5705508320afcc135784b0410a