### PR TITLE
멀티 목적 최적화 trial 로깅 및 스냅샷 개선

### DIFF
--- a/optimize/run.py
+++ b/optimize/run.py
@@ -919,7 +919,8 @@ def optimisation_loop(
             except Exception:
                 return None
 
-        trial_value = _normalise_value(trial.value)
+        raw_value = trial.values if multi_objective else trial.value
+        trial_value = _normalise_value(raw_value)
         record = {
             "number": trial.number,
             "value": trial_value,
@@ -930,7 +931,7 @@ def optimisation_loop(
         with trial_log_path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(record, ensure_ascii=False) + "\n")
 
-        if best_yaml_path is None or multi_objective:
+        if best_yaml_path is None:
             return
         try:
             best_trial = study.best_trial
@@ -938,7 +939,8 @@ def optimisation_loop(
             return
         if best_trial.number != trial.number:
             return
-        best_value = _normalise_value(best_trial.value)
+        best_raw_value = best_trial.values if multi_objective else best_trial.value
+        best_value = _normalise_value(best_raw_value)
         snapshot = {
             "best_value": best_value,
             "best_params": {key: _to_native(val) for key, val in best_trial.params.items()},

--- a/tests/test_run_multi_objective_logging.py
+++ b/tests/test_run_multi_objective_logging.py
@@ -1,0 +1,102 @@
+import json
+
+import pytest
+
+pytest.importorskip("pandas")
+
+import pandas as pd
+import yaml
+
+from optimize.metrics import Trade
+from optimize.run import DatasetSpec, optimisation_loop
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_multi_objective_logging_and_snapshots(tmp_path, monkeypatch):
+    index = pd.date_range("2024-01-01", periods=3, freq="1min")
+    df = pd.DataFrame(
+        {
+            "open": [100.0, 101.0, 102.0],
+            "high": [101.0, 102.0, 103.0],
+            "low": [99.0, 100.0, 101.0],
+            "close": [100.5, 101.5, 102.5],
+            "volume": [10.0, 11.0, 12.0],
+        },
+        index=index,
+    )
+    dataset = DatasetSpec(
+        symbol="BINANCE:TESTUSDT",
+        timeframe="1m",
+        start="2024-01-01",
+        end="2024-01-02",
+        df=df,
+        htf=None,
+        htf_timeframe=None,
+        source_symbol="BINANCE:TESTUSDT",
+    )
+
+    call_counter = {"count": 0}
+
+    def _fake_backtest(df, params, fees, risk, *, htf_df=None):
+        call_counter["count"] += 1
+        base = 0.01 * call_counter["count"]
+        returns = pd.Series([base, -base / 2, 0.0], index=index)
+        trade = Trade(
+            entry_time=index[0],
+            exit_time=index[-1],
+            direction="long",
+            size=1.0,
+            entry_price=100.0,
+            exit_price=100.0 * (1 + base),
+            profit=base,
+            return_pct=base,
+            mfe=base,
+            mae=-base / 2,
+            bars_held=len(index),
+        )
+        return {
+            "Returns": returns,
+            "TradesList": [trade],
+            "Valid": True,
+        }
+
+    monkeypatch.setattr("optimize.run.run_backtest", _fake_backtest)
+
+    params_cfg = {
+        "search": {
+            "multi_objective": True,
+            "n_trials": 2,
+            "algo": "random",
+            "pruner": "nop",
+            "seed": 1,
+        },
+        "space": {},
+    }
+
+    objectives = ["NetProfit", "Sharpe"]
+
+    result = optimisation_loop(
+        [dataset],
+        params_cfg,
+        objectives,
+        fees={},
+        risk={},
+        log_dir=tmp_path,
+    )
+
+    assert result["multi_objective"] is True
+
+    trial_log_path = tmp_path / "trials.jsonl"
+    assert trial_log_path.exists()
+    entries = [json.loads(line) for line in trial_log_path.read_text().splitlines() if line]
+    assert entries, "trials.jsonl에 최소 한 건 이상의 기록이 필요합니다"
+    for entry in entries:
+        assert isinstance(entry["value"], list)
+        assert len(entry["value"]) == len(objectives)
+
+    best_yaml_path = tmp_path / "best.yaml"
+    assert best_yaml_path.exists()
+    snapshot = yaml.safe_load(best_yaml_path.read_text())
+    assert isinstance(snapshot["best_value"], list)
+    assert len(snapshot["best_value"]) == len(objectives)
+    assert all(isinstance(val, float) for val in snapshot["best_value"])


### PR DESCRIPTION
## 요약
- 다중 목적 최적화에서 trial.values와 best_trial.values를 사용해 로그와 스냅샷에 모든 목적 값을 기록하도록 수정했습니다.
- 멀티 목적 설정으로 optimisation_loop를 실행해 trials.jsonl과 best.yaml이 생성되는지를 검증하는 테스트를 추가했습니다.

## 테스트
- pytest tests/test_run_multi_objective_logging.py (환경에 pandas가 없으면 pytest.importorskip 처리로 건너뜁니다)


------
https://chatgpt.com/codex/tasks/task_e_68dba7e5c4408320822dbccbaf4fe732