### PR TITLE
매직1분VN - 백테스트 인덱스 보정 및 멀티코어 설정 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ pip install -r requirements.txt
    - `--timeframe-grid 1m@15m,3m@1h` 으로 여러 LTF/HTF 조합을 일괄 실행 (필요 시 `--study-template`, `--run-tag-template` 으로 이름 규칙 지정)
    - `--leverage`, `--qty-pct`
    - `--n-trials`
+   - `--n-jobs 4` 처럼 Optuna 병렬 worker 수를 지정해 멀티코어를 활용할 수 있습니다.
    - `--enable name1,name2`, `--disable name3`
    - `--top-k 10` to re-rank the best Optuna trials by walk-forward out-of-sample
      performance.

--- a/optimize/quickstart.py
+++ b/optimize/quickstart.py
@@ -115,12 +115,16 @@ def main() -> None:
     disable_tokens: List[str] = []
     if bool_params:
         print("\nToggle optional filters:")
-    for name in bool_params:
-        decision = _prompt_bool(name)
-        if decision is True:
-            enable_tokens.append(name)
-        elif decision is False:
-            disable_tokens.append(name)
+        auto_yes = input("모든 옵션을 예(Enable)로 설정할까요? [y/N]: ").strip().lower()
+        if auto_yes in {"y", "yes"}:
+            enable_tokens.extend(bool_params)
+        else:
+            for name in bool_params:
+                decision = _prompt_bool(name)
+                if decision is True:
+                    enable_tokens.append(name)
+                elif decision is False:
+                    disable_tokens.append(name)
 
     cli_args: List[str] = [
         "--params",


### PR DESCRIPTION
## 요약
- 백테스트 입력 데이터의 인덱스를 검사·보정해 RangeIndex나 timestamp 컬럼을 가진 데이터도 안전하게 처리하고 오류 메시지를 한글로 안내하도록 개선했습니다.
- Quickstart에서 불리언 파라미터를 한 번에 모두 활성화할 수 있는 선택지를 추가해 반복 입력을 줄였습니다.
- Optuna 실행 시 `--n-jobs` 및 `search.n_jobs` 설정을 인식해 멀티코어 병렬 최적화를 지원하고, 관련 CLI 설명과 로깅을 보완했습니다.

## 테스트
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dbf057fcc48320b7d89c190a2c6a41