### PR TITLE
UTC 타임존 사용으로 실행 태그 경고 제거

### DIFF
--- a/optimize/run.py
+++ b/optimize/run.py
@@ -10,7 +10,7 @@ import os
 import subprocess
 from collections.abc import Sequence as AbcSequence
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from itertools import product
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
@@ -112,7 +112,7 @@ def _build_run_tag(
     symbol_slug = _slugify_symbol(str(symbol))
     timeframe_slug = str(timeframe).replace("/", "_")
     htf_slug = str(htf).replace("/", "_")
-    timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M")
+    timestamp = datetime.now(UTC).strftime("%Y%m%d-%H%M")
     parts = [timestamp, symbol_slug, timeframe_slug, htf_slug]
     if run_tag:
         parts.append(run_tag)


### PR DESCRIPTION
## 요약
- `optimize/run.py`의 실행 태그 생성 시 `datetime.utcnow()` 대신 `datetime.now(UTC)`를 사용하도록 수정했습니다.
- `UTC` 상수를 직접 import하여 타임존 인지 datetime 객체를 생성하도록 했습니다.
- 기존 타임스탬프 포맷(`"%Y%m%d-%H%M"`)은 그대로 유지되도록 확인했습니다.

## 테스트
- (경고) `python -Wdefault - <<'PY'` (필요한 `numpy` 모듈이 없어 실행 실패)


------
https://chatgpt.com/codex/tasks/task_e_68dc0b9cbcf0832080c565fcee887bfe