### PR TITLE
핵심 성과 지표 유한값 보장 및 회귀 테스트 추가

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,3 +1,5 @@
+import math
+
 import pandas as pd
 import pytest
 
@@ -56,6 +58,43 @@ def test_aggregate_metrics_basic():
     assert metrics["ProfitFactor"] > 0
     assert "WeeklyNetProfit" in metrics
     assert "Expectancy" in metrics
+
+
+def test_aggregate_metrics_no_losses_is_finite():
+    trades = [
+        Trade(
+            pd.Timestamp("2023-01-01"),
+            pd.Timestamp("2023-01-02"),
+            "long",
+            1.0,
+            100,
+            102,
+            0.02,
+            0.02,
+            0.03,
+            -0.01,
+            3,
+        ),
+        Trade(
+            pd.Timestamp("2023-01-03"),
+            pd.Timestamp("2023-01-04"),
+            "short",
+            1.0,
+            105,
+            103,
+            0.02,
+            0.02,
+            0.02,
+            -0.01,
+            4,
+        ),
+    ]
+    returns = pd.Series([0.01, 0.015, 0.02], index=pd.date_range("2023-01-01", periods=3, freq="D"))
+    metrics = aggregate_metrics(trades, returns)
+
+    assert math.isfinite(metrics["ProfitFactor"])
+    assert math.isfinite(metrics["Sortino"])
+    assert math.isfinite(metrics["Sharpe"])
 
 
 def test_run_backtest_deterministic():


### PR DESCRIPTION
## 요약
- profit_factor, sortino_ratio, sharpe_ratio가 무한대를 반환하지 않도록 EPS 보정 및 0 반환 처리를 적용했습니다.
- aggregate_metrics에서 ProfitFactor, Sortino, Sharpe 값에 대한 유한성 검사를 추가해 비유한 값을 0으로 대체했습니다.
- 손실이 없는 시나리오에서도 핵심 지표가 유한한지 확인하는 회귀 테스트를 추가했습니다.

## 테스트
- pytest tests/test_metrics.py *(pandas 미설치로 실행 불가)*

------
https://chatgpt.com/codex/tasks/task_e_68dcfc0bd0cc8320a289a143fe7f8cc6