### PR TITLE
단순 병렬 최적화 경로 개선

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -448,3 +448,27 @@ def test_combine_metrics_defaults_missing_penalties_to_zero():
     assert combined["TradePenalty"] == pytest.approx(0.0)
     assert combined["HoldPenalty"] == pytest.approx(0.0)
     assert combined["ConsecutiveLossPenalty"] == pytest.approx(0.0)
+
+
+def test_combine_metrics_simple_override_forces_basic_profile():
+    idx = pd.date_range("2024-03-01", periods=5, freq="1H")
+    returns = pd.Series([0.01, -0.005, 0.007, 0.0, 0.012], index=idx)
+    metrics = {
+        "Returns": returns,
+        "GrossProfit": 180.0,
+        "GrossLoss": -90.0,
+        "Trades": 12,
+        "Wins": 7,
+        "Losses": 5,
+        "AvgHoldBars": 3.0,
+        "NetProfit": 0.08,
+        "Valid": True,
+    }
+
+    combined = combine_metrics([metrics], simple_override=True)
+
+    assert combined["SimpleMetricsOnly"] is True
+    assert combined["ProfitFactor"] == pytest.approx(2.0)
+    assert combined["Trades"] == 12
+    assert combined["WinRate"] == pytest.approx(7 / 12)
+    assert combined["Valid"] is True

--- a/tests/test_run_helpers.py
+++ b/tests/test_run_helpers.py
@@ -5,9 +5,11 @@ import pytest
 
 from optimize.run import (
     DatasetSpec,
+    _filter_basic_factor_params,
     _group_datasets,
     _normalise_periods,
     _resolve_symbol_entry,
+    _restrict_to_basic_factors,
     _select_datasets_for_params,
     parse_args,
 )
@@ -66,6 +68,38 @@ def test_parse_args_accepts_trial_override():
     args = parse_args(["--n-trials", "25"])
 
     assert args.n_trials == 25
+
+
+def test_parse_args_exposes_space_flags():
+    args = parse_args(["--full-space"])
+
+    assert args.full_space is True
+    assert args.basic_factors_only is False
+
+    args = parse_args(["--basic-factors-only"])
+
+    assert args.full_space is False
+    assert args.basic_factors_only is True
+
+
+def test_basic_factor_filter_toggle():
+    space = {"oscLen": {"type": "int"}, "custom": {"type": "int"}}
+
+    restricted = _restrict_to_basic_factors(space)
+    assert restricted == {"oscLen": {"type": "int"}}
+
+    restored = _restrict_to_basic_factors(space, enabled=False)
+    assert restored == {"oscLen": {"type": "int"}, "custom": {"type": "int"}}
+
+
+def test_basic_factor_param_filter_toggle():
+    params = {"oscLen": 12, "custom": 7}
+
+    filtered = _filter_basic_factor_params(params)
+    assert filtered == {"oscLen": 12}
+
+    unfiltered = _filter_basic_factor_params(params, enabled=False)
+    assert unfiltered == params
 
 
 def _make_dataset(timeframe: str, htf: Optional[str]) -> DatasetSpec:


### PR DESCRIPTION
## 요약
- `combine_metrics`에 단순 경로 강제 플래그를 추가하고, ProfitFactor 전용 계산 시 거래 목록 결합 없이 핵심 지표를 재집계하도록 최적화했습니다.
- 단순 ProfitFactor 모드 활성 여부를 로깅하고, 데이터셋 병렬 실행 기본값을 프로세스 기반으로 조정하며 Optuna worker 수를 자동으로 보정했습니다.
- 단순 계산 강제 경로가 예상대로 동작하는지 확인하는 단위 테스트를 추가했습니다.

## 테스트
- `python -m compileall optimize/run.py tests/test_metrics.py`
- `pytest tests/test_metrics.py` *(numpy 미설치로 수집 단계에서 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68dd49a3df7883208d2e05d00685d08d