### PR TITLE
LLM 후보 정렬 보완 및 HTF 시드 분리

### DIFF
--- a/optimize/run.py
+++ b/optimize/run.py
@@ -271,6 +271,8 @@ def _resolve_output_directory(
     run_tag: Optional[str],
 ) -> Tuple[Path, Dict[str, str]]:
     ts, symbol_slug, timeframe_slug, tag = _build_run_tag(datasets, params_cfg, run_tag)
+    htf_value = _extract_primary_htf(params_cfg, datasets)
+    htf_slug = _slugify_timeframe(htf_value)
     if base is None:
         root = DEFAULT_REPORT_ROOT
         output = root / tag
@@ -282,6 +284,7 @@ def _resolve_output_directory(
         "timestamp": ts,
         "symbol": symbol_slug,
         "timeframe": timeframe_slug,
+        "htf_timeframe": htf_slug,
         "tag": tag,
     }
 
@@ -408,6 +411,10 @@ def _discover_bank_path(
             continue
         if metadata.get("timeframe") != tag_info.get("timeframe"):
             continue
+        metadata_htf = metadata.get("htf_timeframe") or "nohtf"
+        target_htf = tag_info.get("htf_timeframe") or "nohtf"
+        if metadata_htf != target_htf:
+            continue
         return bank_path
     return None
 
@@ -477,6 +484,7 @@ def _build_bank_payload(
         "metadata": {
             "symbol": tag_info.get("symbol"),
             "timeframe": tag_info.get("timeframe"),
+            "htf_timeframe": tag_info.get("htf_timeframe"),
             "tag": tag_info.get("tag"),
         },
         "space_hash": space_hash,


### PR DESCRIPTION
## 요약
- 멀티 목적 최적화 트라이얼도 안전하게 정렬할 수 있도록 LLM 후보 추출 로직을 보완했습니다.
- LLM 프롬프트에 다중 지표 값을 포함하고 우선순위 산정 기준을 개선했습니다.
- 은행 시드 복구 시 HTF 정보까지 확인하도록 메타데이터를 확장해 오염을 방지했습니다.

## 테스트
- python -m compileall optimize/llm.py optimize/run.py

------
https://chatgpt.com/codex/tasks/task_e_68de0fb7c05c832090f4f1c3362eb933