### PR TITLE
ROI 시간 계산 보정

### DIFF
--- a/PPP_KASIA_Maxguard.pine
+++ b/PPP_KASIA_Maxguard.pine
@@ -779,7 +779,7 @@ trailStopPctLong  = trailTriggerLong ? close * (1 - trailPct) : na
 trailStopPctShort = trailTriggerShort ? close * (1 + trailPct) : na
 
 barsInTrade = strategy.opentrades > 0 ? bar_index - strategy.opentrades.entry_bar_index(0) : na
-tradeMinutes = strategy.opentrades > 0 ? (timenow - strategy.opentrades.entry_time(0)) / 60000 : na
+tradeMinutes = strategy.opentrades > 0 ? math.max(0, (nz(timenow, time) - strategy.opentrades.entry_time(0)) / 60000) : na
 roiHitLong = strategy.position_size > 0 and not na(tradeMinutes) and (
      (roi1MinEff > 0 and tradeMinutes >= roi1MinEff and close >= strategy.position_avg_price * (1 + roi1PctEff / 100.0)) or
      (roi2MinEff > 0 and tradeMinutes >= roi2MinEff and close >= strategy.position_avg_price * (1 + roi2PctEff / 100.0)) or


### PR DESCRIPTION
## 요약
- tradeMinutes 계산에서 `timenow` 대신 `nz(timenow, time)`을 사용하도록 수정했습니다.
- 음수 방지를 위해 `tradeMinutes`를 최소 0으로 보정하여 ROI 조건 계산의 안정성을 높였습니다.

## 테스트
- TradingView 전략 백테스트 환경 필요로 인해 로컬 테스트를 수행하지 못했습니다.


------
https://chatgpt.com/codex/tasks/task_e_68df9e04cdfc8320a3fa39ddd67c219c