### PR TITLE
트레일 스탑 캐시 갱신 로직 개선

### DIFF
--- a/PPP_KASIA_Maxguard.pine
+++ b/PPP_KASIA_Maxguard.pine
@@ -775,8 +775,24 @@ percentTakeShort = strategy.position_size < 0 ? strategy.position_avg_price * (1
 trailTriggerLong = strategy.position_size > 0 and close >= strategy.position_avg_price * (1 + trailStartEff / 100.0)
 trailTriggerShort= strategy.position_size < 0 and close <= strategy.position_avg_price * (1 - trailStartEff / 100.0)
 trailPct = trailGapEff / 100.0
-trailStopPctLong  = trailTriggerLong ? close * (1 - trailPct) : na
-trailStopPctShort = trailTriggerShort ? close * (1 + trailPct) : na
+var float trailStopPctLongCache = na
+var float trailStopPctShortCache = na
+
+trailStopPctLongCurrent  = close * (1 - trailPct)
+trailStopPctShortCurrent = close * (1 + trailPct)
+
+if not trailTriggerLong
+    trailStopPctLongCache := na
+else
+    trailStopPctLongCache := na(trailStopPctLongCache) ? trailStopPctLongCurrent : math.max(trailStopPctLongCache, trailStopPctLongCurrent)
+
+if not trailTriggerShort
+    trailStopPctShortCache := na
+else
+    trailStopPctShortCache := na(trailStopPctShortCache) ? trailStopPctShortCurrent : math.min(trailStopPctShortCache, trailStopPctShortCurrent)
+
+trailStopPctLong  = trailStopPctLongCache
+trailStopPctShort = trailStopPctShortCache
 
 barsInTrade = strategy.opentrades > 0 ? bar_index - strategy.opentrades.entry_bar_index(0) : na
 tradeMinutes = strategy.opentrades > 0 ? (timenow - strategy.opentrades.entry_time(0)) / 60000 : na


### PR DESCRIPTION
## 요약
- 트레일링 스탑 퍼센트 값을 var 캐시로 저장하고 트리거 발생 시 초기화하도록 수정했습니다.
- 롱과 숏 각각에 대해 최고/최저 값만 유지하도록 하여 가격이 되돌릴 때 스탑이 후퇴하지 않도록 했습니다.
- stopFinal 계산이 새 캐시 값을 참고하도록 정리했습니다.

## 테스트
- python - <<'PY'  # 롱 트레일링 스탑 캐시 시뮬레이션
- python - <<'PY'  # 숏 트레일링 스탑 캐시 시뮬레이션


------
https://chatgpt.com/codex/tasks/task_e_68df9e0593188320b22b33df252b4ce1