### PR TITLE
3Commas 알림 커스터마이징 옵션 추가

### DIFF
--- a/PPP_KASIA_Maxguard.pine
+++ b/PPP_KASIA_Maxguard.pine
@@ -19,6 +19,7 @@ var GRP_FILTER = "E) 모멘텀/구조 필터"
 var GRP_SL     = "F) 손절 & 유틸"
 var GRP_HUD    = "G) HUD & 디버거"
 var GRP_DEMO   = "H) 데모 테스트 로직"
+var GRP_ALERT  = "Q) 알림 & 연동"
 
 // ---- 시간 & 세션 ----
 startYear   = input.int(2024, "백테스트 시작 연도", minval=2017, group=GRP_TIME)
@@ -266,6 +267,12 @@ maxTradesPerDay = input.int(0, "일일 최대 신규 진입 (0=무제한)", 0, 5
 lossCooldownBars = input.int(10, "손실 후 쿨다운 봉", 0, 500, group=GRP_PPP_RISK)
 // 3Commas 연동용 입력 변수 추가
 alert_qty_value = input.float(100.0, "3Commas 알림 수량 (%)", group=GRP_PPP_RISK, tooltip="3Commas 연동 시 사용할 자본 비율(%)입니다.")
+
+use3commasAlert = input.bool(true, "3Commas 알림 활성화", group=GRP_ALERT, tooltip="3Commas 또는 기타 자동매매 서비스에 전달할 알림을 사용할지 설정합니다.")
+alert_msg_long_open  = input.string('{{"action":"open","side":"long","symbol":"{0}","leverage":{1},"cap_pct":{2}}}', "롱 진입 메시지", group=GRP_ALERT, tooltip="필요 시 {0}=심볼, {1}=레버리지, {2}=주문 자본 % 를 사용해 메시지를 구성하세요.")
+alert_msg_short_open = input.string('{{"action":"open","side":"short","symbol":"{0}","leverage":{1},"cap_pct":{2}}}', "숏 진입 메시지", group=GRP_ALERT, tooltip="필요 시 {0}=심볼, {1}=레버리지, {2}=주문 자본 % 를 사용해 메시지를 구성하세요.")
+alert_msg_long_close = input.string('{{"action":"close","side":"long","symbol":"{0}"}}', "롱 청산 메시지", group=GRP_ALERT, tooltip="필요 시 {0}=심볼, {1}=레버리지, {2}=주문 자본 % 를 사용해 메시지를 구성하세요.")
+alert_msg_short_close= input.string('{{"action":"close","side":"short","symbol":"{0}"}}', "숏 청산 메시지", group=GRP_ALERT, tooltip="필요 시 {0}=심볼, {1}=레버리지, {2}=주문 자본 % 를 사용해 메시지를 구성하세요.")
 
 
 presetSelect(userValue, scalperValue, baseValue, swingValue)=>
@@ -967,10 +974,12 @@ if showDebugger and barstate.islast
 // Alerts (3Commas 연동용)
 // =====================================================================
 
-// [수정됨] 'default_qty_value'를 새로 만든 'alert_qty_value' 변수로 교체
-makeJSON(_action, _side)=>
-    str.format('{{"action":"{0}","side":"{1}","symbol":"{2}","leverage":{3},"cap_pct":{4}}}',
-      _action, _side, syminfo.ticker, leverage, alert_qty_value)
+formatAlert(_template)=>
+    str.format(_template, syminfo.ticker, leverage, alert_qty_value)
+
+sendAlert(_condition, _template)=>
+    if _condition and use3commasAlert
+        alert(formatAlert(_template), alert.freq_once_per_bar)
 
 longOpen   = canLong
 shortOpen  = canShort
@@ -978,11 +987,7 @@ longClose  = strategy.position_size > 0 and (shortSig or (not na(longStop)  and 
 shortClose = strategy.position_size < 0 and (longSig  or (not na(shortStop) and high >= shortStop))
 
 
-if longOpen
-    alert(makeJSON("open","long"), alert.freq_once_per_bar)
-if shortOpen
-    alert(makeJSON("open","short"), alert.freq_once_per_bar)
-if longClose
-    alert(makeJSON("close","long"), alert.freq_once_per_bar)
-if shortClose
-    alert(makeJSON("close","short"), alert.freq_once_per_bar)
+sendAlert(longOpen,  alert_msg_long_open)
+sendAlert(shortOpen, alert_msg_short_open)
+sendAlert(longClose, alert_msg_long_close)
+sendAlert(shortClose,alert_msg_short_close)


### PR DESCRIPTION
## 개요
- 3Commas 연동용 알림 메시지를 사용자가 직접 편집할 수 있도록 입력 항목을 추가했습니다.
- 알림 생성 로직을 함수화하여 필요 시 손쉽게 확장하거나 비활성화할 수 있도록 개선했습니다.

## 테스트
- 적용 가능한 자동 테스트가 없어 별도 테스트는 수행하지 않았습니다.

------
https://chatgpt.com/codex/tasks/task_e_68dff5f6fff08320bb309c0b5b5ff1a4