### PR TITLE
매직1분VN - PAR 배열 초기화 오류 수정

### DIFF
--- a/BaseModule
+++ b/BaseModule
@@ -265,7 +265,7 @@ if barstate.isconfirmed
 currentDD      = peakEquity > 0 ? (peakEquity - strategy.equity) / peakEquity * 100 : 0.0
 scaledRiskPct  = useDrawdownScaling and currentDD > drawdownTriggerPct ? baseRiskPct * drawdownRiskScale : baseRiskPct
 
-var float recentTradeResults[] = array.new_float()
+var float[] recentTradeResults = array.new_float()
 var int lastClosedCount = 0
 closedCount = strategy.closedtrades
 if usePerfAdaptiveRisk and closedCount > lastClosedCount


### PR DESCRIPTION
## Summary
- PAR(성과 적응 리스크) 섹션에서 최근 거래 결과 배열 선언을 Pine Script v5 규격에 맞게 수정하여 컴파일 오류를 제거했습니다.

## Testing
- 해당 없음 (TradingView Pine Script 환경 필요)


------
https://chatgpt.com/codex/tasks/task_e_68e678f45e348320bd4d613eaf71fda9